### PR TITLE
Validate Repo Nanny package with structural CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,27 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  structure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check roster and README drift
+        run: python3 scripts/sync-roster.py --check
+
+      - name: Validate library structure and relative links
+        run: python3 scripts/validate-structure.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   structure:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/validate-structure.py
+++ b/scripts/validate-structure.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Lightweight structural validation for the Agents-of-AI library.
+
+Stdlib-only by design. This validates repository structure and references; it does
+not score or judge prompt content.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LAYERS = ("personas", "agents", "workflows", "techniques", "modes", "teams")
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def front_matter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        return {"__error__": "unterminated front matter"}
+    fields: dict[str, str] = {}
+    for raw in text[4:end].splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def relative_links(path: Path, text: str):
+    for match in LINK_RE.finditer(text):
+        raw = match.group(1).strip()
+        if not raw or raw.startswith(("http://", "https://", "mailto:", "#", "data:")):
+            continue
+        target = raw.split("#", 1)[0].split("?", 1)[0]
+        if not target or target.startswith("/"):
+            continue
+        yield raw, (path.parent / target).resolve()
+
+
+def main() -> int:
+    errors: list[str] = []
+    ids: dict[str, Path] = {}
+    files_checked = 0
+
+    for layer in LAYERS:
+        folder = ROOT / layer
+        if not folder.is_dir():
+            errors.append(f"missing layer directory: {layer}/")
+            continue
+
+        for path in sorted(folder.glob("*.md")):
+            files_checked += 1
+            text = path.read_text(encoding="utf-8")
+            meta = front_matter(text)
+            rel = path.relative_to(ROOT)
+
+            if "__error__" in meta:
+                errors.append(f"{rel}: {meta['__error__']}")
+                continue
+
+            # Library entries are expected to carry an ID when they use front matter.
+            # Legacy prose-only files remain allowed; CI is structural, not migratory.
+            if meta:
+                entry_id = meta.get("id", "").strip('"\'')
+                entry_type = meta.get("type", "").strip('"\'')
+                if not entry_id:
+                    errors.append(f"{rel}: front matter missing id")
+                else:
+                    prior = ids.get(entry_id)
+                    if prior is not None:
+                        errors.append(
+                            f"duplicate id '{entry_id}': {prior.relative_to(ROOT)} and {rel}"
+                        )
+                    else:
+                        ids[entry_id] = path
+                if not entry_type:
+                    errors.append(f"{rel}: front matter missing type")
+
+            for raw, resolved in relative_links(path, text):
+                try:
+                    resolved.relative_to(ROOT)
+                except ValueError:
+                    errors.append(f"{rel}: relative link escapes repository: {raw}")
+                    continue
+                if not resolved.exists():
+                    errors.append(f"{rel}: broken relative link: {raw}")
+
+    if errors:
+        print("STRUCTURE VALIDATION FAILED")
+        for error in errors:
+            print(f"- {error}")
+        print(f"\nChecked {files_checked} library files; found {len(errors)} error(s).")
+        return 1
+
+    print(f"STRUCTURE VALIDATION OK: {files_checked} library files, {len(ids)} unique IDs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stacks the structural CI work on top of PR #3 so validation runs against the intended synchronized Agents-of-AI state rather than stale `main` roster snapshots.

### Why stacked
The original CI PR #5 correctly exposed pre-existing prompt-roster drift on `main` (`second-room` existed in `workflows/` but the generated prompt snapshots still listed 8 workflows). PR #3 already synchronizes those generated rosters while adding Repo Nanny, Human Gate Committee, and Single Dispatch Operator.

### Checks
- `python3 scripts/sync-roster.py --check`
- stdlib-only `python3 scripts/validate-structure.py`
- duplicate IDs
- required `id` / `type` when front matter exists
- broken relative links
- README/prompt roster drift

### Merge order
1. Human-review/merge PR #3.
2. Retarget this PR to `main` if GitHub does not do so automatically.
3. Human-review/merge this CI PR after green validation.

No runtime framework, paid dependency, content-scoring gate, merge automation, or governance authority is introduced.